### PR TITLE
fix: refactor setupStore initialization for each render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 yarn.lock
 package-lock.json
 dist/
+.vscode/settings.json

--- a/tests-rtl/tests/utils.ts
+++ b/tests-rtl/tests/utils.ts
@@ -1,20 +1,24 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import { Provider } from "starfx/react";
-import { schema } from "../src/api";
-import { setupStore } from "../src/store";
+import React from 'react';
 
-const AllTheProviders = ({ children }) => {
-  const store = setupStore({});
-  return (
-    <Provider schema={schema} store={store}>
-      {children}
-    </Provider>
-  );
-};
+import { Provider } from 'starfx/react';
 
-const customRender = (ui, options) =>
-  render(ui, { wrapper: AllTheProviders, ...options });
+import { render } from '@testing-library/react';
+
+import { schema } from '../src/api';
+import { setupStore } from '../src/store';
+
+const customRender = (ui, options) => {
+  const AllTheProviders = ({ children }) => {
+    const store = setupStore({});
+    return (
+      <Provider schema={schema} store={store}>
+        {children}
+      </Provider>
+    );
+  };
+
+  return render(ui, { wrapper: AllTheProviders, ...options });
+}
 
 // re-export everything
 export * from "@testing-library/react";


### PR DESCRIPTION
This PR refactors the customRender function to ensure that a new store is created for each render by moving the setupStore call inside the function. This provides isolation between tests and prevents shared state between renders.